### PR TITLE
Simple possible implementation of SEUMailChecker (Continuously updating)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,8 @@
+{
+  "imap": {
+    "server": "imap.seu.edu.cn",
+    "user": "username",
+    "password": "password"
+  },
+  "interval": 5
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,42 @@
+import sys
+import email
+import imaplib
+import json
+from time import sleep
+from threading import Thread
+
+
+with open("config.json") as config_file:
+    config_json = json.load(config_file)
+    imap_server = config_json["imap"]["server"]
+    imap_user = config_json["imap"]["user"]
+    imap_password = config_json["imap"]["password"]
+    check_interval = config_json["interval"]
+
+
+mail_conn = imaplib.IMAP4_SSL(imap_server)
+(ret, caps) = mail_conn.login(imap_user, imap_password)
+
+
+if __name__ == "__main__":
+    current_latest_mail_id = 0 # 记录当前的最新邮件的id
+
+    while True:
+        mail_conn.list() # 获取邮件箱列表 
+        mail_conn.select("inbox") # 选择当前邮件箱为收件箱；btw，不清楚这三步中哪一步才正式向服务器取数据……
+        (result, messages) = mail_conn.search(None, "ALL") # 获取收件箱的所有邮件ID
+
+        if result == "OK":
+            latest_mail_id = messages[0].split(b" ")[-1] # 获取最新的邮件id
+            if current_latest_mail_id != latest_mail_id:
+                (ret, res) = mail_conn.fetch(latest_mail_id, "RFC822") # 根据id向服务器发送请求
+                msg = email.message_from_bytes(res[0][1]) # 从响应中解析出邮件头（没有正文）
+                
+                # 进一步验证 or 做要做的事
+                print(msg["Subject"]) # 打印邮件标题
+                pass
+
+                current_latest_mail_id = latest_mail_id # 更新最新的邮件id
+
+        print("After this round, current latest mail id is", current_latest_mail_id.decode("utf-8"))
+        sleep(check_interval) # 等待一小段时间后再次检查


### PR DESCRIPTION
## Introduction
### Investigations
最理想的解决方案自然是邮件服务器能够主动推送新邮件信息。
关于主动推送功能，可以参考知乎上的[这个回答](https://www.zhihu.com/question/30406583/answer/64111783)。
很显然，对于SEU的邮件服务器，私有协议/Exchange是不存在的，只能寄希望于IMAP的IDLE Command。
参考这个[获取服务器可用扩展](https://www.limilabs.com/blog/get-supported-server-extensions-imap-pop3-smtp)的方法，在imap.seu.edu.cn上跑了一下，结果是并不支持IDLE……
因此，主动推送方案是基本没戏了┑(￣Д ￣)┍ 

### Final solution
因此，想要达到即时推送的效果，只能通过不断骚扰学校服务器来完成了_(:з」∠)_

大致思路如下：
1. 与学校的邮箱服务器保持长连接
2. 本地保存一份当前最新邮件的信息 
3. 不断获取收件箱中的邮件列表，找出最新的邮件，与本地记录的邮件信息进行比对
4. 若最新邮件更新了，通过相关API请求Win10邮箱UWP刷新邮件列表

此方案似乎更适合作为一个小型App部署在服务器上……可以减少本地的网络负荷
但由于需要提醒邮件UWP更新，本地仍须持续运行一个监听服务。

### Usage
1. 拷贝一份config.example.json至同目录下，重命名为config.json。
2. 在config.json中填入校园邮箱的用户名与密码，设置检查邮箱的周期。
3. 后台运行main.py。

## Features
### Accomplished
- [x] 连接至学校IMAP邮件服务器
- [x] 持续对邮箱中是否有新邮件进行判断

### To-do
- [ ] 模拟登录QQ邮箱，使其能自动刷新
- [ ] 连接至Win10邮件UWP，使其能自动刷新
- [ ] 移动端设备支持？
- [ ] 也许更适合部署在一个服务器上？

## Others
还是感觉这个Repo很有意思23333各种方面上233333
今天是你的生日，这个PR就当作我的生日礼物吧~ ~~争取在今天更新出能用的东西~~。
生日快乐！
 
## Updates
### 2018/1/9
目光先转向了QQ邮箱(〜￣△￣)〜
因为若能让QQ邮箱自动收取，则在PC端和移动端都可以随时即时接收邮件
但是……虽然登进QQ邮箱网页版后，想进行刷新非常容易（调用）
但在python中想模拟操作真是前路多艰啊……
可以参考下这个[csdn博文](http://blog.csdn.net/astraylinux/article/details/77978425)。